### PR TITLE
Fixed Lang

### DIFF
--- a/src/main/resources/assets/subsistence/lang/en_US.lang
+++ b/src/main/resources/assets/subsistence/lang/en_US.lang
@@ -39,6 +39,7 @@ tile.spawn_marker.name=Nether Spawn Marker
 tile.infernal_log.name=Infernal Log
 tile.infernal_leaves.name=Infernal Leaves
 tile.infernal_sapling.name=Hellfire Sapling
+tile.boiling_water.name=Boiling Water
 
 # MACHINES
 tile.table.wood.name=Wooden Table
@@ -49,9 +50,14 @@ tile.hammer_mill.name=Hammer Mill
 tile.water_mill.name=Water Mill
 tile.kiln.name=Kiln
 tile.metal_press.name=Metal Press
-tile.barrel.wood.name=Wooden Barrel
-tile.barrel.stone.name=Stone Barrel
+tile.barrel.Wood.name=Wooden Barrel
+tile.barrel.Stone.name=Stone Barrel
+tile.compost.Wood.name=Wooden Compost Bin
+tile.compost.Stone.name=Stone Compost Bin
 tile.infernal_furnace.name=Hellfire Furnace
+tile.kinetic_crank.name=Kinetic Crank
+tile.crank.name=Crank
+tile.metal_shaft.name=Metal Shaft
 
 # LIMESTONE
 tile.limestone.limestone.name=Limestone
@@ -70,15 +76,21 @@ tile.storage.steel.name=Steel Block
 tile.storage.tin.name=Tin Block
 
 # MISC TOOLS
-item.net.name=Net
+item.net.normal.name=Net
+item.net.flies.name=Net with Flies
 item.hand_sieve.name=Hand Sieve
 item.boiling_bucket.name=Boiling Water Bucket
 
 # MISC ITEMS
 item.component_item.twine.name=Twine
 item.component_item.twine_mesh.name=Twine Mesh
-item.seed.grass.name=Grass Seeds
-item.seed.nether_grass=Nether Grass Seeds
+item.seeds.grass.name=Grass Seeds
+item.seeds.nether_grass=Nether Grass Seeds
+item.tray.name=Tray
+item.barrel_lid.Wood.name=Wooden Barrel Lid
+item.barrel_lid.Stone.name=Stone Barrel Lid
+item.cosmetic.corruption.name=Charm of Corruption
+item.cosmetic.righteousness.name=Charm of Righteousness
 
 # RESOURCE ITEMS
 item.resource.chunk.name=%s Chunk

--- a/src/main/resources/assets/subsistence/lang/en_US.lang
+++ b/src/main/resources/assets/subsistence/lang/en_US.lang
@@ -89,8 +89,8 @@ item.seeds.nether_grass=Nether Grass Seeds
 item.tray.name=Tray
 item.barrel_lid.Wood.name=Wooden Barrel Lid
 item.barrel_lid.Stone.name=Stone Barrel Lid
-item.cosmetic.corruption.name=Charm of Corruption
-item.cosmetic.righteousness.name=Charm of Righteousness
+item.cosmetic.corruption.name=Heart of Corruption
+item.cosmetic.righteousness.name=Heart of Righteousness
 
 # RESOURCE ITEMS
 item.resource.chunk.name=%s Chunk


### PR DESCRIPTION
Some items and blocks weren't assigned to the right unlocalized name and some blocks and items didn't even have an entry in the lang file, hehe. So yeah, here's the fixed version that has been tested.
Everything works fine, however, when I want to localize the Nether Grass Seeds it says ingame "Nether Grass Seeds.name". That is clearly not the unlocalized name but for some reason there is a ".name" at the end, @lclc98.
I also named both hearts Charms because they had a prefix of "cosmetic." so I thought charm would fit. If you want it to be "Heart of..." I can it.
Oh well, thanks in advance :)
